### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,6 @@
 v3.0.50
 - Bug fix Container Manager and Docker where moving `@docker` would cause an error. 
 - Changed to not exit on error moving app's `@folders`.
-- Added warning that moving `@docker` could take a long time.
 - Bug fix for message showing `@download` if not enough space on target volume to move `@docker`.
 
 v3.0.49

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 v3.0.50
 - Bug fix Container Manager and Docker where moving `@docker` would cause an error. 
 - Changed to not exit on error moving app's `@folders`.
+- Changed from hardcoded 50GB buffer to user configurable buffer (used when checking if there's enough space to move folder).
 - Bug fix for message showing `@download` if not enough space on target volume to move `@docker`.
 
 v3.0.49

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+v3.0.50
+- Bug fix Container Manager and Docker where moving `@docker` would cause an error. 
+- Changed to not exit on error moving app's `@folders`.
+- Bug fix for message showing `@download` if not enough space on target volume to move `@docker`.
+
 v3.0.49
 - Bug fix for Synology Drive still using `@synologydrive` on the original volume. Issue #55
 - Now deletes `@eaDir` folders to try to prevent `mv: cannot remove '/volume#/@<folder>': Operation not permitted`. Issue #54

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 v3.0.50
+- Bug fix for Hyper backup where moving `@img_bkp_cache` could cause an error. Issue #54
 - Bug fix Container Manager and Docker where moving `@docker` could cause an error. Issues #34 #38 #46
 - Changed to not exit on error moving app's `@folders`.
 - Changed from hardcoded 50GB buffer to user configurable buffer (used when checking if there's enough space to move folder).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 v3.0.50
-- Bug fix Container Manager and Docker where moving `@docker` would cause an error. 
+- Bug fix Container Manager and Docker where moving `@docker` could cause an error. Issues #34 #38 #46
 - Changed to not exit on error moving app's `@folders`.
 - Changed from hardcoded 50GB buffer to user configurable buffer (used when checking if there's enough space to move folder).
 - Bug fix for message showing `@download` if not enough space on target volume to move `@docker`.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 v3.0.50
 - Bug fix Container Manager and Docker where moving `@docker` would cause an error. 
 - Changed to not exit on error moving app's `@folders`.
+- Added warning that moving `@docker` could take a long time.
 - Bug fix for message showing `@download` if not enough space on target volume to move `@docker`.
 
 v3.0.49

--- a/syno_app_mover.conf
+++ b/syno_app_mover.conf
@@ -1,5 +1,5 @@
 # buffer is used when checking if target volume has enough space
-# Add 50GB so we don't fill the volume
+# Add 50 GB buffer so we don't fill the target volume
 
 buffer=50
 

--- a/syno_app_mover.conf
+++ b/syno_app_mover.conf
@@ -1,3 +1,8 @@
+# buffer is used when checking if target volume has enough space
+# Add 50GB so we don't fill the volume
+
+buffer=50
+
 # backuppath should be in the format of /volume/sharename/folder
 # For example:
 # backuppath="/volume1/backups"
@@ -10,4 +15,4 @@ backuppath="/volume1/backups"
 # Set to "0" to always backup
 # skip_minutes is in minutes
 
-skip_minutes="360"
+skip_minutes=360

--- a/syno_app_mover.sh
+++ b/syno_app_mover.sh
@@ -35,7 +35,6 @@
 # DSM 6 to 7.1.1 bug fix for not detecting when package was not installed (for Restore mode).
 #
 #
-#
 # DONE Bug fix for moving @docker
 #
 # DONE Bug fix for not editing /var/packages/Calendar/etc/share_link.json. Issue #39


### PR DESCRIPTION
v3.0.50
- Bug fix for Hyper backup where moving `@img_bkp_cache` could cause an error. Issue #54
- Bug fix Container Manager and Docker where moving `@docker` could cause an error. Issues #34 #38 #46
- Changed to not exit on error moving app's `@folders`.
- Changed from hardcoded 50GB buffer to user configurable buffer (used when checking if there's enough space to move folder).
- Bug fix for message showing `@download` if not enough space on target volume to move `@docker`.