### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+v4.2.77
+- Changed timout for starting and stoping apps from 5 minutes to 30 minutes. Issue #140
+  - Container Manager with lots of containers takes longer than 5 minutes to stop or start.
+- Changed to only use the timeout when there is more than 1 app to backup or restore. Issue #140
+- Bug fix for 'bad array subscript' when app is missing it's INFO file. Issue #138
+- Bug fix for checking free space on USB drives. Issue #138
+
 v4.2.76
 - Changed timout for starting and stoping apps from 5 minutes to 30 minutes. Issue #140
   - Container Manager with lots of containers takes longer than 5 minutes to stop or start.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 v4.2.76
-- Changed timout for starting and stoping apps from 5 minutes to 30 minutes.
-- Changed to only use the timeout when there is more than 1 app to backup or restore.
+- Changed timout for starting and stoping apps from 5 minutes to 30 minutes. Issue #140
+  - Container Manager with lots of containers takes longer than 5 minutes to stop or start.
+- Changed to only use the timeout when there is more than 1 app to backup or restore. Issue #140
 
 v4.2.75
 - Added `@database` as an app that can be moved.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v4.2.76
+- Changed timout for starting and stoping apps from 5 minutes to 30 minutes.
+- Changed to only use the timeout when there is more than 1 app to backup or restore.
+
 v4.2.75
 - Added `@database` as an app that can be moved.
   - Only needed if moving all apps to a different volume so you can delete the old volume.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,11 +5,6 @@ v4.2.77
 - Bug fix for 'bad array subscript' when app is missing it's INFO file. Issue #138
 - Bug fix for checking free space on USB drives. Issue #138
 
-v4.2.76
-- Changed timout for starting and stoping apps from 5 minutes to 30 minutes. Issue #140
-  - Container Manager with lots of containers takes longer than 5 minutes to stop or start.
-- Changed to only use the timeout when there is more than 1 app to backup or restore. Issue #140
-
 v4.2.75
 - Added `@database` as an app that can be moved.
   - Only needed if moving all apps to a different volume so you can delete the old volume.


### PR DESCRIPTION
v4.2.77
- Changed timout for starting and stoping apps from 5 minutes to 30 minutes. Issue #140
  - Container Manager with lots of containers takes longer than 5 minutes to stop or start.
- Changed to only use the timeout when there is more than 1 app to backup or restore. Issue #140
- Bug fix for 'bad array subscript' when app is missing it's INFO file. Issue #138
- Bug fix for checking free space on USB drives. Issue #138