### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,12 +1,10 @@
 v4.2.78
-- Bug fix for log filename starting with "scriptname" instead of "syno_app_mover".
-
-v4.2.77
 - Changed timeout for starting and stopping apps from 5 minutes to 30 minutes. Issue #140
   - Container Manager with lots of containers takes longer than 5 minutes to stop or start.
 - Changed to only use the timeout when there is more than 1 app to backup or restore. Issue #140
 - Bug fix for 'bad array subscript' when app is missing it's INFO file. Issue #138
 - Bug fix for checking free space on USB drives. Issue #138
+- Bug fix for log filename starting with "scriptname" instead of "syno_app_mover".
 
 v4.2.75
 - Added `@database` as an app that can be moved.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v4.2.78
+- Bug fix for log filename starting with "scriptname" instead of "syno_app_mover".
+
 v4.2.77
 - Changed timeout for starting and stopping apps from 5 minutes to 30 minutes. Issue #140
   - Container Manager with lots of containers takes longer than 5 minutes to stop or start.

--- a/syno_app_mover.sh
+++ b/syno_app_mover.sh
@@ -27,12 +27,12 @@
 # DONE Added USB Copy to show how to move USB Copy database (move mode only)
 #------------------------------------------------------------------------------
 
-scriptver="v4.2.77"
+scriptver="v4.2.78"
 script=Synology_app_mover
 repo="007revad/Synology_app_mover"
 scriptname=syno_app_mover
 logpath="$(dirname "$(realpath "$0")")"
-logfile="$logpath/scriptname_$(date +%Y-%m-%d_%H-%M).log"
+logfile="$logpath/$scriptname_$(date +%Y-%m-%d_%H-%M).log"
 
 # Prevent Entware or user edited PATH causing issues
 # shellcheck disable=SC2155  # Declare and assign separately to avoid masking return values
@@ -142,9 +142,14 @@ list_names(){
             if [[ ! -a "$p/target" ]] ; then
                 echo -e "\e[41mBroken symlink\e[0m $p"
             else
-                long_name="$(/usr/syno/bin/synogetkeyvalue "/var/packages/${p}/INFO" displayname)"
-                if [[ -z "$long_name" ]]; then
-                    long_name="$(/usr/syno/bin/synogetkeyvalue "/var/packages/${p}/INFO" package)"
+                if [[ -f "/var/packages/${p}/INFO" ]]; then
+                    long_name="$(/usr/syno/bin/synogetkeyvalue "/var/packages/${p}/INFO" displayname)"
+                    if [[ -z "$long_name" ]]; then
+                        long_name="$(/usr/syno/bin/synogetkeyvalue "/var/packages/${p}/INFO" package)"
+                    fi
+                else
+                    # Package with no INFO file
+                    long_name="!!! MISSING INFO FILE !!!"
                 fi
                 # Pad with spaces to 29 chars
                 pad=$(printf -- ' %.0s' {1..29})


### PR DESCRIPTION
- Bug fix for 'bad array subscript' when app is missing it's INFO file. Issue #138
- Bug fix for checking free space on USB drives. Issue #138
- Bug fix for log filename starting with "scriptname" instead of "syno_app_mover".